### PR TITLE
Add support for WIF strings

### DIFF
--- a/lib/RPuzzle.js
+++ b/lib/RPuzzle.js
@@ -20,8 +20,8 @@ const RValue = require('./RValue');
  *
  * @constructor
  * @param {KValue|RValue} val
- * @param {PrivateKey|HDPrivateKey} key - Optional
- * @param {string|number} path - Optional, required if key is defined
+ * @param {PrivateKey|HDPrivateKey|String} key - Optional, WIF format if given as String
+ * @param {string|number} path - Optional, required if key is a HDPrivateKey
  */
 function RPuzzle(val, key=null, path=null) {
     if (!(this instanceof RPuzzle)) {
@@ -49,6 +49,8 @@ function RPuzzle(val, key=null, path=null) {
                 p = path;
             }
             this.privateKey = key.deriveChild(p).privateKey;
+        } else if (typeof key === 'string') {
+            this.privateKey = PrivateKey.fromWIF(key);
         } else {
             throw new TypeError("Expected instance of PrivateKey or HDPrivateKey")
             


### PR DESCRIPTION
This is a simple change that enabled people to provide a WIF-formatted private key string as the second parameter.

I was having an issue where `key instanceof PrivateKey` was failing due to a complex peer dependency hoisting problem in my project (a `bsv@1.5.3` PrivateKey is not an instance of `bsv@1.5.4` PrivateKey).

This provides a fix, and also makes it more convenient for anyone else.